### PR TITLE
Removed double trdata-entry in units

### DIFF
--- a/src/Makefile.fpc
+++ b/src/Makefile.fpc
@@ -1,7 +1,7 @@
 [clean]
 units = trdata trfile trreader trhtmlstripper icudet \
   icuconv icuwrappers icunorm trsecondpass trcharsetconverter \
-  trentityconverters fann icuregex icutypes icuutils trdata \
+  trentityconverters fann icuregex icutypes icuutils \
   trdocumentprocessor trqueues trutilities trtexrex trdeboilerplater \
   trsimpledocumentfilter trunicodeletterrangetokenizer trshingler \
   trfrequencyprofiler trtypefrequencies trbloom trtextassessment \
@@ -29,7 +29,7 @@ programs = texrex texcomm tenet tender tecl arcxi rofl hydra cowsplit \
 
 units = trdata trfile trreader trhtmlstripper icudet \
   icuconv icuwrappers icunorm trsecondpass trcharsetconverter \
-  trentityconverters fann icuregex icutypes icuutils trdata \
+  trentityconverters fann icuregex icutypes icuutils \
   trdocumentprocessor trqueues trutilities trtexrex trdeboilerplater \
   trsimpledocumentfilter trunicodeletterrangetokenizer trshingler \
   trbloom trtextassessment trutf8validator trworker trnormalizer \


### PR DESCRIPTION
`trdata` was added twice in the list of units, making the installation fail with the error "will not overwrite just-created `trdata` with `trdata`".

Removing one of them resolved the error. The remaining trdata is still on the first line.
